### PR TITLE
Remove redundant committee member name.

### DIFF
--- a/committees/programming-and-education.md
+++ b/committees/programming-and-education.md
@@ -5,7 +5,7 @@ This committee is governed by the joint [Terms of Reference](/committees/terms-o
 ## Current Members
 
 * **Chair:** Izzie Colpitts-Campbell
-* **Members:** Yifat Shaik, Jennie Robinson Faber, Jen Costa, Kaitlin Tremblay, Bee Goodwin, Mic Fok, Kae Bagg, Bee Goodwin
+* **Members:** Yifat Shaik, Jennie Robinson Faber, Jen Costa, Kaitlin Tremblay, Bee Goodwin, Mic Fok, Kae Bagg
 
 
 ## Responsibilities


### PR DESCRIPTION
Bee was listed twice, just noticed when I was writing this grant.